### PR TITLE
Include babel-loader as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.7.7",
+    "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "solc-loader": "^1.0.0-rc.3",
     "web3": "^0.15.3",


### PR DESCRIPTION
I could very well be wrong, but I think that babel-loader webpack plugin is required.
